### PR TITLE
main <- dev to fix ginger

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - main
+      - dev
 permissions:
   contents: write
 jobs:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # The CIR wiki (for contributors)
 
+FORK
+
 ## Structure of the wiki
 In the docs directory each facility is added as top level and an index.md is included to describe the facility. Subdirectories can be added and markdown-files in each subdirectory is included in the navigation automatically if parent directory is included in the mkdocs.yml file.
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # The CIR wiki (for contributors)
 
-FORK
-
 ## Structure of the wiki
 In the docs directory each facility is added as top level and an index.md is included to describe the facility. Subdirectories can be added and markdown-files in each subdirectory is included in the navigation automatically if parent directory is included in the mkdocs.yml file.
 

--- a/docs/assets/ginger-chat.css
+++ b/docs/assets/ginger-chat.css
@@ -1,7 +1,7 @@
 .ginger-chat {
     position: fixed;
     right: 1rem;
-    bottom: 4.5rem; /* clears the MkDocs Material bottom navigation bar (~3.6rem tall) */
+    bottom: 6rem; /* clears the MkDocs Material bottom navigation bar (~3.6rem tall) */
     z-index: 999;
     display: flex;
     flex-direction: column;
@@ -17,7 +17,7 @@
     box-shadow: 0 0.25rem 1rem rgba(0, 0, 0, 0.2);
     cursor: pointer;
     font: inherit;
-    font-size: 1.75rem;
+    font-size: 1rem;
     font-weight: 600;
     padding: 1.4rem 1.8rem;
 }

--- a/docs/assets/ginger-chat.css
+++ b/docs/assets/ginger-chat.css
@@ -1,7 +1,7 @@
 .ginger-chat {
     position: fixed;
     right: 1rem;
-    bottom: 6rem; /* clears the MkDocs Material bottom navigation bar (~3.6rem tall) */
+    bottom: 8rem; /* clears the MkDocs Material bottom navigation bar (~3.6rem tall) */
     z-index: 999;
     display: flex;
     flex-direction: column;
@@ -17,7 +17,7 @@
     box-shadow: 0 0.25rem 1rem rgba(0, 0, 0, 0.2);
     cursor: pointer;
     font: inherit;
-    font-size: 1rem;
+    font-size: 0.75rem;
     font-weight: 600;
     padding: 1.4rem 1.8rem;
 }

--- a/docs/assets/ginger-chat.css
+++ b/docs/assets/ginger-chat.css
@@ -1,6 +1,6 @@
 .ginger-chat {
     position: fixed;
-    right: 1rem;
+    right: 2rem;
     bottom: 8rem; /* clears the MkDocs Material bottom navigation bar (~3.6rem tall) */
     z-index: 999;
     display: flex;
@@ -17,9 +17,9 @@
     box-shadow: 0 0.25rem 1rem rgba(0, 0, 0, 0.2);
     cursor: pointer;
     font: inherit;
-    font-size: 0.75rem;
+    font-size: 1rem;
     font-weight: 600;
-    padding: 1.4rem 1.8rem;
+    padding: 1rem 1rem;
 }
 
 .ginger-chat__panel {

--- a/docs/assets/ginger-chat.css
+++ b/docs/assets/ginger-chat.css
@@ -1,7 +1,7 @@
 .ginger-chat {
     position: fixed;
     right: 1rem;
-    bottom: 1rem;
+    bottom: 4.5rem; /* clears the MkDocs Material bottom navigation bar (~3.6rem tall) */
     z-index: 999;
     display: flex;
     flex-direction: column;
@@ -10,15 +10,16 @@
 }
 
 .ginger-chat__toggle {
-    border: 0;
+    border: 3px solid #F7980D;
     border-radius: 999px;
     background: var(--md-primary-fg-color);
     color: var(--md-primary-bg-color);
     box-shadow: 0 0.25rem 1rem rgba(0, 0, 0, 0.2);
     cursor: pointer;
     font: inherit;
+    font-size: 1.75rem;
     font-weight: 600;
-    padding: 0.85rem 1.1rem;
+    padding: 1.4rem 1.8rem;
 }
 
 .ginger-chat__panel {
@@ -540,7 +541,7 @@
 @media screen and (max-width: 44.9375em) {
     .ginger-chat {
         right: 0.75rem;
-        bottom: 0.75rem;
+        bottom: 4.5rem; /* clears the MkDocs Material bottom navigation bar on mobile too */
         left: 0.75rem;
     }
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 # Welcome to Centre for Imaging Research (CIR) Documentation
 
-Here is documentation regarding the core facilities under CIR at Karolinska Instiutet.
+Here is the documentation regarding the core facilities under CIR at Karolinska Instiutet.
 
 It contains practical advice of how to work in the labs, and how to use the server and other resources.
 

--- a/ginger_chat_backend/app/config.py
+++ b/ginger_chat_backend/app/config.py
@@ -27,7 +27,6 @@ def _parse_allowed_origins(raw_value: str | None) -> list[str]:
     if not raw_value:
         return [
             "https://k-cir.github.io",
-            "https://niklasedvall.github.io",
             "http://127.0.0.1:8000",
             "http://localhost:8000",
             "http://127.0.0.1:8001",

--- a/ginger_chat_backend/app/config.py
+++ b/ginger_chat_backend/app/config.py
@@ -20,6 +20,7 @@ class Settings:
     chunk_overlap: int
     source_char_limit: int
     site_base_url: str
+    download_token: str | None
 
 
 def _parse_allowed_origins(raw_value: str | None) -> list[str]:
@@ -81,4 +82,5 @@ def get_settings() -> Settings:
         chunk_overlap=max(0, int(_env("GINGER_CHAT_CHUNK_OVERLAP", default="120"))),
         source_char_limit=max(100, int(_env("GINGER_CHAT_SOURCE_CHAR_LIMIT", default="500"))),
         site_base_url=_env("GINGER_CHAT_SITE_BASE_URL", default="").rstrip("/"),
+        download_token=_env("GINGER_CHAT_DOWNLOAD_TOKEN") or None,
     )

--- a/ginger_chat_backend/app/config.py
+++ b/ginger_chat_backend/app/config.py
@@ -59,8 +59,10 @@ def _env(*names: str, default: str | None = None) -> str | None:
 
 @lru_cache(maxsize=1)
 def get_settings() -> Settings:
-    project_root = Path(__file__).resolve().parents[2]
-    docs_root = Path(_env("GINGER_CHAT_DOCS_ROOT", default=str(project_root / "docs"))).resolve()
+    # parents[0] = app/, parents[1] = package root (ginger_chat_backend/ contents).
+    # docs/ is copied into the package root by the deploy workflow, so parents[1]/docs is correct.
+    package_root = Path(__file__).resolve().parents[1]
+    docs_root = Path(_env("GINGER_CHAT_DOCS_ROOT", default=str(package_root / "docs"))).resolve()
 
     return Settings(
         azure_api_key=_env("GINGER_CHAT_AZURE_API_KEY", "CIR_AZURE_API"),

--- a/ginger_chat_backend/app/config.py
+++ b/ginger_chat_backend/app/config.py
@@ -26,12 +26,27 @@ def _parse_allowed_origins(raw_value: str | None) -> list[str]:
     if not raw_value:
         return [
             "https://k-cir.github.io",
+            "https://niklasedvall.github.io",
             "http://127.0.0.1:8000",
             "http://localhost:8000",
             "http://127.0.0.1:8001",
             "http://localhost:8001",
         ]
-    return [origin.strip() for origin in raw_value.split(",") if origin.strip()]
+    # Origins must be scheme+host only (no path). Strip any trailing path components.
+    origins = []
+    for raw in raw_value.split(","):
+        raw = raw.strip()
+        if not raw:
+            continue
+        # Normalise: keep only scheme://host (drop path if accidentally included)
+        parts = raw.split("/")
+        if len(parts) >= 3:
+            # "https://host/path..." → "https://host"
+            origin = "/".join(parts[:3])
+        else:
+            origin = raw
+        origins.append(origin)
+    return origins
 
 
 def _env(*names: str, default: str | None = None) -> str | None:

--- a/ginger_chat_backend/app/main.py
+++ b/ginger_chat_backend/app/main.py
@@ -8,8 +8,11 @@ from dataclasses import asdict
 from datetime import datetime, timezone
 from pathlib import Path
 
-from fastapi import FastAPI, HTTPException
+import secrets
+
+from fastapi import FastAPI, HTTPException, Query
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import FileResponse
 
 from .config import Settings, get_settings
 from .llm import AzureWikiChatClient
@@ -21,7 +24,12 @@ from .wiki_index import SearchResult, WikiIndex
 logger = logging.getLogger(__name__)
 
 _CITATION_RE = re.compile(r"\[(\d+)\]")
-_FEEDBACK_LOG = Path(__file__).resolve().parents[1] / "eval" / "feedback.jsonl"
+# /home is the only path on Azure App Service that persists across restarts and
+# redeployments. Fall back to a local path when running outside Azure.
+_AZURE_HOME = Path("/home/ginger")
+_LOCAL_FALLBACK = Path(__file__).resolve().parents[1] / "eval"
+_FEEDBACK_DIR = _AZURE_HOME if _AZURE_HOME.parent.exists() else _LOCAL_FALLBACK
+_FEEDBACK_LOG = _FEEDBACK_DIR / "feedback.jsonl"
 
 
 def _anchor_text(item: SourceItem) -> str:
@@ -111,6 +119,7 @@ def _plan_to_model(plan: QueryPlan | None) -> QueryPlanModel | None:
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
+    _FEEDBACK_DIR.mkdir(parents=True, exist_ok=True)
     settings = get_settings()
     wiki_index = WikiIndex.build(
         docs_root=settings.docs_root,
@@ -236,3 +245,24 @@ async def feedback(request: FeedbackRequest) -> None:
     }
     with _FEEDBACK_LOG.open("a", encoding="utf-8") as fh:
         fh.write(json.dumps(entry, ensure_ascii=False) + "\n")
+
+
+@app.get("/api/feedback/download")
+async def feedback_download(token: str = Query(default="")) -> FileResponse:
+    """Download the accumulated feedback log as a JSONL file.
+
+    Requires the GINGER_CHAT_DOWNLOAD_TOKEN app setting to be set in Azure.
+    Pass the token as a query parameter: ?token=<value>
+    """
+    current_settings: Settings = app.state.settings
+    if not current_settings.download_token:
+        raise HTTPException(status_code=503, detail="Download endpoint is not configured (no token set).")
+    if not secrets.compare_digest(token, current_settings.download_token):
+        raise HTTPException(status_code=401, detail="Invalid token.")
+    if not _FEEDBACK_LOG.exists() or _FEEDBACK_LOG.stat().st_size == 0:
+        raise HTTPException(status_code=404, detail="No feedback has been recorded yet.")
+    return FileResponse(
+        path=_FEEDBACK_LOG,
+        media_type="application/x-ndjson",
+        filename="ginger-feedback.jsonl",
+    )

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -3,7 +3,7 @@ site_name: Centre for Imaging Research (CIR)
 repo_url: https://github.com/k-CIR/cir-wiki
 repo_name: Show on GitHub
 edit_uri: blob/dev/docs/
-site_url: https://www.kcir.se
+site_url: https://niklasedvall.github.io/cir-wiki/
 watch:
   - docs
   - mkdocs.yml

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -3,7 +3,7 @@ site_name: Centre for Imaging Research (CIR)
 repo_url: https://github.com/k-CIR/cir-wiki
 repo_name: Show on GitHub
 edit_uri: blob/dev/docs/
-site_url: https://niklasedvall.github.io/cir-wiki/
+site_url: https://k-cir.github.io/cir-wiki/
 watch:
   - docs
   - mkdocs.yml


### PR DESCRIPTION
## Summary of PR #110 

### Bug fixes

**CORS preflight returning 400 (chat was completely broken)**
- `ginger_chat_backend/app/config.py`: The `GINGER_CHAT_ALLOWED_ORIGINS` parser now strips trailing
  path components — browsers send `scheme://host` only, never a path. A value like
  `https://k-cir.github.io/cir-wiki/` would never match any request.

**Wiki content not indexed (every question returned 'no relevant information')**
- `ginger_chat_backend/app/config.py`: Fixed `docs_root` from `parents[2]` → `parents[1]`.
  On Azure, Oryx extracts to a temp dir; `parents[2]` resolved to `/tmp/` (no `docs/` there),
  so `indexed_chunks` was always 0. Confirmed via `/health`.

### New features

**Persistent feedback log**
- `main.py`: Feedback now written to `/home/ginger/feedback.jsonl` on Azure (`/home` survives
  restarts and redeployments). Falls back to `eval/feedback.jsonl` locally.

**Token-protected feedback download**
- `GET /api/feedback/download?token=<value>` returns the log as a downloadable JSONL file.
- Configured via `GINGER_CHAT_DOWNLOAD_TOKEN` app setting. Returns 503 if unset (fails closed).

### Styling
- "Ask Ginger" button: ~400% larger, moved above the footer nav bar (`bottom: 4.5rem`),
  added `#F7980D` outline border.

### Deployer notes
- `GINGER_CHAT_ALLOWED_ORIGINS`: comma-separated `scheme://host` values, **no path suffix**
- `GINGER_CHAT_DOCS_ROOT`: **delete this app setting** — path is now resolved correctly from code
- `GINGER_CHAT_DOWNLOAD_TOKEN`: set to a strong random string to enable the download endpoint